### PR TITLE
CAS-184: changed upload limit on gallery images

### DIFF
--- a/docroot/profiles/custom/stanford_profile/config/sync/field.field.media.stanford_gallery_images.su_gallery_image.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/field.field.media.stanford_gallery_images.su_gallery_image.yml
@@ -22,7 +22,7 @@ settings:
   handler_settings: {  }
   file_directory: media/image/gallery
   file_extensions: 'png gif jpg jpeg'
-  max_filesize: 5MB
+  max_filesize: 30MB
   max_resolution: ''
   min_resolution: ''
   alt_field: true


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Upload limit on gallery was 5 Mb. Can't use workaround of individual file upload. I changed it to accommodate moving over existing gallery data.

# Review By (Date)
- Pre-launch

# Urgency
- High, since it blocks finishing the galleries

# Steps to Test

1. Navigate to a gallery
2. Try to upload something that is 7 Mbs
3. Cry a little because that image should really be resized, imo
4. Rejoice because at least the image can be uploaded and we can meet the client needs for now!

# Affected Projects or Products
- Does this PR impact any particular projects, products, or modules?

# Associated Issues and/or People
- CAS-184

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
