### PR TITLE
CAS-191: Updated settings for HTML format

### DIFF
--- a/docroot/profiles/custom/stanford_profile/config/sync/editor.editor.stanford_html.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/editor.editor.stanford_html.yml
@@ -18,7 +18,6 @@ settings:
       - horizontalLine
       - style
       - heading
-      - removeFormat
       - '|'
       - link
       - '|'
@@ -125,7 +124,8 @@ settings:
     media_media:
       allow_view_mode_override: true
     linkit_extension:
-      linkit_enabled: false
+      linkit_enabled: true
+      linkit_profile: default
 image_upload:
   status: false
   scheme: public

--- a/docroot/profiles/custom/stanford_profile/config/sync/filter.format.stanford_html.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/filter.format.stanford_html.yml
@@ -55,10 +55,10 @@ filters:
   filter_html:
     id: filter_html
     provider: filter
-    status: false
+    status: true
     weight: -50
     settings:
-      allowed_html: '<b> <cite> <dt> <pre class> <code data-* class> <dl class> <dd class> <div id class> <i class> <aside class> <img src alt title class> <abbr id title> <span id class> <blockquote cite> <ul id type class> <ol id type class> <li id class> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <table id class> <tbody class> <th scope id class> <td id class> <tr id> <drupal-media data-* title> <a aria-label hreflang data-entity-substitution data-entity-type data-entity-uuid title name class> <p id class>'
+      allowed_html: '<br> <p class id> <h2 id class> <h3 id class> <h4 id class> <h5 id class> <a class aria-label hreflang data-entity-substitution data-entity-type data-entity-uuid title name href> <b> <cite> <dt> <pre class> <code data-* class> <dl class> <dd class> <div id class> <i class> <aside class> <img src alt title class> <abbr id title> <span id class> <blockquote cite> <ul id type class> <ol id type class start> <li id class> <table id class> <tbody class> <th scope id class rowspan colspan> <td id class rowspan colspan> <tr id> <drupal-media data-* title alt> <strong> <em> <s> <sub> <sup> <hr> <thead> <tfoot> <caption>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_htmlcorrector:

--- a/docroot/profiles/custom/stanford_profile/config/sync/user.role.authenticated.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/user.role.authenticated.yml
@@ -3,7 +3,6 @@ langcode: en
 status: true
 dependencies:
   config:
-    - filter.format.stanford_html
     - filter.format.stanford_minimal_html
   module:
     - field_permissions
@@ -22,7 +21,6 @@ permissions:
   - 'access content'
   - 'access patterns page'
   - 'access shortcuts'
-  - 'use text format stanford_html'
   - 'use text format stanford_minimal_html'
   - 'view field_media_embeddable_code'
   - 'view media'

--- a/docroot/profiles/custom/stanford_profile/config/sync/user.role.contributor.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/user.role.contributor.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.stanford_html
     - media.type.file
     - media.type.google_form
     - media.type.image
@@ -22,6 +23,7 @@ dependencies:
     - dropzonejs
     - eck
     - editoria11y
+    - filter
     - media
     - menu_admin_per_menu
     - node
@@ -108,6 +110,7 @@ permissions:
   - 'mark as hidden in editoria11y'
   - 'schedule publishing of nodes'
   - 'update media'
+  - 'use text format stanford_html'
   - 'view all revisions'
   - 'view any log entities'
   - 'view any unpublished stanford_course content'

--- a/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_builder.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_builder.yml
@@ -9,6 +9,7 @@ dependencies:
     - core.entity_view_display.node.stanford_page.default
     - core.entity_view_display.node.stanford_person.default
     - core.entity_view_display.node.stanford_publication.default
+    - filter.format.stanford_html
     - media.type.embeddable
     - media.type.file
     - media.type.google_form
@@ -55,6 +56,7 @@ dependencies:
     - field_permissions
     - field_ui
     - file
+    - filter
     - image
     - layout_builder
     - media
@@ -343,6 +345,7 @@ permissions:
   - 'update any media'
   - 'update any stanford_component_block block content'
   - 'update media'
+  - 'use text format stanford_html'
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'

--- a/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_developer.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_developer.yml
@@ -9,6 +9,7 @@ dependencies:
     - core.entity_view_display.node.stanford_page.default
     - core.entity_view_display.node.stanford_person.default
     - core.entity_view_display.node.stanford_publication.default
+    - filter.format.stanford_html
     - media.type.embeddable
     - media.type.file
     - media.type.google_form
@@ -392,6 +393,7 @@ permissions:
   - 'update any media'
   - 'update any stanford_component_block block content'
   - 'update media'
+  - 'use text format stanford_html'
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'

--- a/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_editor.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_editor.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.stanford_html
     - media.type.embeddable
     - media.type.file
     - media.type.google_form
@@ -39,6 +40,7 @@ dependencies:
     - eck
     - editoria11y
     - field_permissions
+    - filter
     - media
     - menu_admin_per_menu
     - node
@@ -218,6 +220,7 @@ permissions:
   - 'revert stanford_publication revisions'
   - 'schedule publishing of nodes'
   - 'update media'
+  - 'use text format stanford_html'
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'

--- a/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_manager.yml
+++ b/docroot/profiles/custom/stanford_profile/config/sync/user.role.site_manager.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - filter.format.stanford_html
     - media.type.embeddable
     - media.type.file
     - media.type.google_form
@@ -42,6 +43,7 @@ dependencies:
     - eck
     - editoria11y
     - field_permissions
+    - filter
     - media
     - menu_admin_per_menu
     - node
@@ -265,6 +267,7 @@ permissions:
   - 'update any media'
   - 'update any stanford_component_block block content'
   - 'update media'
+  - 'use text format stanford_html'
   - 'use views bulk edit'
   - 'view all media revisions'
   - 'view all revisions'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Restricted use of HTML to Contributors, Editors, Admin, Site Developer, Site Manager, Site Builder. I removed Authenticated User.
-I removed the Remove Format button from the CKeditor toolbar
-I turned on LinkIt again (Not sure why that change didn’t make it through my other PR)
-I reinstated the filter to “Limit allowed HTML tags and correct faulty HTML”

# Review By (Date)
- Before launch

# Urgency
- It will save sitebuilding time, so would like it soon

# Steps to Test

1. Paste in some terrible formatting in any element that uses the HTML format
2. Notice that the formatting doesn't come along for the ride
3. Try using the LinkIt tool
4. Breathe a sigh of relief that things are back to an expected state for anyone coming to the site as an editor

# Affected Projects or Products
- None, as far as I can tell

# Associated Issues and/or People
- CAS-191
- @brucedyoung 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
